### PR TITLE
Fix case of environment variable

### DIFF
--- a/scraper/CoursebookScraper.ts
+++ b/scraper/CoursebookScraper.ts
@@ -517,7 +517,7 @@ export class CoursebookScraper extends FirefoxScraper {
         // Log in with COURSEBOOK_AUTH credentials
         await this.Login({
             NetID: process.env.NETID,
-            Password: process.env.Password
+            Password: process.env.PASSWORD
         });
         // Find the term buttons
         let TermButtons = await this.FindDropdownButtons(CoursebookScraper.DropdownIDs.TERM, TermIndexStart, TermIndexEnd);


### PR DESCRIPTION
On UNIX environments it is case sensitive. It worked on my Windows laptop just fine but on my Linux machine I needed to change this to be all capitalized.